### PR TITLE
Restructure error message if needed

### DIFF
--- a/lib/microServiceRouter.js
+++ b/lib/microServiceRouter.js
@@ -249,6 +249,12 @@ function microServiceRouter(message, handleResponse) {
           handleMicroService.call(self, message, route, destination, function(response) {
             delete response.finished;
             delete response.type;
+            if (!response.message && response.error) {
+              response.message = {
+                error: response.error
+              }
+              delete response.error;
+            }                   
             if (response.message.error) noOfErrors++;
             if (!token && response.message.token) {
               token = response.message.token + '';


### PR DESCRIPTION
If a destination is down, the response only contains an error + status but no message property. The code added fixes this - similar to line 228.