### PR TITLE
Patch 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - '11'
+  - '10'
   - '9'
   - '8'
   - '7'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ewd-qoper8-express: Express integration module for ewd-qoper8
 
-[![Build Status](https://travis-ci.org/robtweed/ewd-qoper8-express.svg?branch=master)](https://travis-ci.org/robtweed/ewd-qoper8-express) [![Coverage Status](https://coveralls.io/repos/github/robtweed/ewd-qoper8-express/badge.svg?branch=master)](https://coveralls.io/github/robtweed/ewd-qoper8-express?branch=master) [![Dependency Status](https://gemnasium.com/badges/github.com/robtweed/ewd-qoper8-express.svg)](https://gemnasium.com/github.com/robtweed/ewd-qoper8-express)
+[![Build Status](https://travis-ci.org/robtweed/ewd-qoper8-express.svg?branch=master)](https://travis-ci.org/robtweed/ewd-qoper8-express) [![Coverage Status](https://coveralls.io/repos/github/robtweed/ewd-qoper8-express/badge.svg?branch=master)](https://coveralls.io/github/robtweed/ewd-qoper8-express?branch=master) [![Dependency Status](https://david-dm.org/robtweed/ewd-qoper8-express.svg)](https://david-dm.org/robtweed/ewd-qoper8-express) [![npm version](https://img.shields.io/npm/v/ewd-qoper8-express.svg)](https://www.npmjs.com/package/ewd-qoper8-express)
 
 Rob Tweed <rtweed@mgateway.com>  
 24 February 2016-17, M/Gateway Developments Ltd [http://www.mgateway.com](http://www.mgateway.com).
@@ -95,7 +95,7 @@ DEBUG=ewd-qoper8-express server.js
 ## License
 
 ```
- Copyright (c) 2016 M/Gateway Developments Ltd,                           
+ Copyright (c) 2016-2019 M/Gateway Developments Ltd,                           
  Reigate, Surrey UK.                                                      
  All rights reserved.                                                     
                                                                            

--- a/package.json
+++ b/package.json
@@ -40,22 +40,22 @@
     ]
   },
   "dependencies": {
-    "debug": "^3.1.0",
-    "express": "^4.16.2",
-    "qewd-microservice-router": "^1.0.0"
+    "debug": "^4.1.1",
+    "express": "^4.16.3",
+    "qewd-microservice-router": "^1.2.11"
   },
   "devDependencies": {
-    "body-parser": "^1.18.2",
-    "coveralls": "^3.0.0",
+    "body-parser": "^1.18.3",
+    "coveralls": "^3.0.2",
     "ewd-qoper8": "^3.16.1",
-    "jasmine": "^2.9.0",
+    "jasmine": "^3.3.1",
     "jasmine-spec-reporter": "^4.1.1",
-    "jasmine-spy-matchers": "^1.2.0",
-    "jshint": "^2.9.5",
+    "jasmine-spy-matchers": "^2.2.0",
+    "jshint": "^2.9.7",
     "mockery": "^2.1.0",
     "nyc": "^11.4.1",
     "pre-commit": "^1.2.2",
-    "rewire": "^2.5.2",
-    "supertest": "^3.0.0"
+    "rewire": "^4.0.1",
+    "supertest": "^3.4.1"
   }
 }

--- a/spec/integration/qewd-response-headers/server.js
+++ b/spec/integration/qewd-response-headers/server.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var path = require('path');
+var express = require('express');
+var bodyParser = require('body-parser');
+var qoper8 = require('ewd-qoper8');
+var qx = require('../../../');
+var utils = require('../utils');
+
+var app = express();
+app.use(bodyParser.json());
+
+var q = new qoper8.masterProcess();
+qx.addTo(q);
+
+app.get('/qoper8/rest-message', function (req, res) {
+  qx.handleMessage(req, res);
+});
+
+app.use(utils.errorHandler());
+
+app.use(function (err, req, res, next) { // jshint ignore:line
+  res.status(err.status || 500);
+  res.status(err.status).send(err.response);
+});
+
+q.on('start', function () {
+  this.worker.module = path.join(__dirname, 'worker-module');
+  this.log = false;
+});
+
+q.on('started', function () {
+  app.listen(8080, function () {
+    process.send({
+      type: 'express-started'
+    });
+  });
+});
+
+q.start();

--- a/spec/integration/qewd-response-headers/testrunner.spec.js
+++ b/spec/integration/qewd-response-headers/testrunner.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var request = require('supertest')('http://localhost:8080');
+var utils = require('../utils');
+
+describe('integration/ewd-qoper8-express/qewd-response-headers:', function () {
+  var cp;
+
+  beforeAll(function (done) {
+    cp = utils.fork(require.resolve('./server'), done);
+  });
+
+  afterAll(function (done) {
+    utils.exit(cp, done);
+  });
+
+  it('should set response headers', function (done) {
+    request.
+      get('/qoper8/rest-message').
+      expect(200).
+      expect('x-foo', 'bar').
+      expect('x-quux', 'baz').
+      expect(function (res) {
+        var body = res.body;
+        expect(body).toEqual({});
+      }).
+      end(function (err) {
+        return err ? done.fail(err) : done();
+      });
+  });
+});

--- a/spec/integration/qewd-response-headers/worker-module.js
+++ b/spec/integration/qewd-response-headers/worker-module.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = function () {
+
+  this.on('message', function (messageObj, send, finished) {
+    var results;
+
+    if (messageObj.path === '/qoper8/rest-message') {
+      /*jshint camelcase: false */
+      results = {
+        restMessage: true,
+        qewd_response_headers: {
+          'x-foo': 'bar',
+          'x-quux': 'baz',
+        }
+      };
+      /*jshint camelcase: true */
+
+      return finished(results);
+    }
+
+    this.emit('unknownMessage', messageObj, send, finished);
+  });
+
+};

--- a/spec/integration/send-jwt-as-cookie/server.js
+++ b/spec/integration/send-jwt-as-cookie/server.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var path = require('path');
+var express = require('express');
+var bodyParser = require('body-parser');
+var qoper8 = require('ewd-qoper8');
+var qx = require('../../../');
+var utils = require('../utils');
+
+var app = express();
+app.use(bodyParser.json());
+
+var q = new qoper8.masterProcess();
+qx.addTo(q);
+
+app.get('/qoper8/:type', function (req, res) {
+  qx.handleMessage(req, res);
+});
+
+app.use(utils.errorHandler());
+
+app.use(function (err, req, res, next) { // jshint ignore:line
+  res.status(err.status || 500);
+  res.status(err.status).send(err.response);
+});
+
+q.on('start', function () {
+  this.worker.module = path.join(__dirname, 'worker-module');
+  this.log = false;
+});
+
+q.on('started', function () {
+  app.listen(8080, function () {
+    process.send({
+      type: 'express-started'
+    });
+  });
+});
+
+q.start();

--- a/spec/integration/send-jwt-as-cookie/testrunner.spec.js
+++ b/spec/integration/send-jwt-as-cookie/testrunner.spec.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var request = require('supertest')('http://localhost:8080');
+var utils = require('../utils');
+
+describe('integration/ewd-qoper8-express/send-jwt-as-cookie:', function () {
+  var cp;
+
+  beforeAll(function (done) {
+    cp = utils.fork(require.resolve('./server'), done);
+  });
+
+  afterAll(function (done) {
+    utils.exit(cp, done);
+  });
+
+  it('should set cookie (basic)', function (done) {
+    request.
+      get('/qoper8/basic').
+      expect(200).
+      expect('set-cookie', 'JSESSIONID=foo.bar.baz; path=/').
+      expect(function (res) {
+        var body = res.body;
+        expect(body).toEqual({});
+      }).
+      end(function (err) {
+        return err ? done.fail(err) : done();
+      });
+  });
+
+  it('should set cookie (custom name)', function (done) {
+    request.
+      get('/qoper8/custom-name').
+      expect(200).
+      expect('set-cookie', 'QUUX=foo.bar.baz; path=/').
+      expect(function (res) {
+        var body = res.body;
+        expect(body).toEqual({});
+      }).
+      end(function (err) {
+        return err ? done.fail(err) : done();
+      });
+  });
+
+  it('should set cookie (directives)', function (done) {
+    request.
+      get('/qoper8/directives').
+      expect(200).
+      expect('set-cookie', 'JSESSIONID=foo.bar.baz; path=/xxx; HttpOnly').
+      expect(function (res) {
+        var body = res.body;
+        expect(body).toEqual({});
+      }).
+      end(function (err) {
+        return err ? done.fail(err) : done();
+      });
+  });
+});

--- a/spec/integration/send-jwt-as-cookie/worker-module.js
+++ b/spec/integration/send-jwt-as-cookie/worker-module.js
@@ -1,0 +1,54 @@
+'use strict';
+
+module.exports = function () {
+
+  this.on('message', function (messageObj, send, finished) {
+    var results;
+
+    if (messageObj.path === '/qoper8/basic') {
+      /*jshint camelcase: false */
+      results = {
+        restMessage: true,
+        qewd_send_jwt_as_cookie: true,
+        token: 'foo.bar.baz'
+      };
+      /*jshint camelcase: true */
+
+      return finished(results);
+    }
+
+    if (messageObj.path === '/qoper8/custom-name') {
+      /*jshint camelcase: false */
+      results = {
+        restMessage: true,
+        qewd_send_jwt_as_cookie: {
+          name: 'QUUX'
+        },
+        token: 'foo.bar.baz'
+      };
+      /*jshint camelcase: true */
+
+      return finished(results);
+    }
+
+    if (messageObj.path === '/qoper8/directives') {
+      /*jshint camelcase: false */
+      results = {
+        restMessage: true,
+        qewd_send_jwt_as_cookie: {
+          directives: [
+           'path=/xxx',
+           'HttpOnly'
+          ]
+        },
+        token: 'foo.bar.baz'
+      };
+      /*jshint camelcase: true */
+
+      return finished(results);
+    }
+
+    this.emit('unknownMessage', messageObj, send, finished);
+  });
+
+};

--- a/spec/unit/express.spec.js
+++ b/spec/unit/express.spec.js
@@ -486,6 +486,236 @@ describe('unit/express:', function () {
 
           expect(res.locals.message.restMessage).toBeUndefined();
         });
+
+        describe('qewd response headers', function () {
+          it('should ignore response headers (not an object)', function () {
+            /*jshint camelcase: false */
+            resultObj.message.qewd_response_headers = 'foo';
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.locals.message.qewd_response_headers).toBe('foo');
+            /*jshint camelcase: true */
+          });
+
+          it('should set response headers', function () {
+            /*jshint camelcase: false */
+            resultObj.message.qewd_response_headers = {
+              'x-foo': 'bar'
+            };
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.set).toHaveBeenCalledWith('x-foo', 'bar');
+            expect(res.locals.message.qewd_response_headers).toBeUndefined();
+            /*jshint camelcase: true */
+          });
+        });
+
+        describe('send jwt as cookie', function () {
+          it('should set cookie with default name', function () {
+            /*jshint camelcase: false */
+            resultObj.message = {
+              qewd_send_jwt_as_cookie: true,
+              token: 'foo.bar.baz',
+              restMessage: {}
+            };
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.set).toHaveBeenCalledWith('Set-Cookie', 'JSESSIONID=foo.bar.baz; path=/');
+            expect(res.locals.message.qewd_send_jwt_as_cookie).toBeUndefined();
+            expect(res.locals.message.token).toBeUndefined();
+            /*jshint camelcase: true */
+          });
+
+          it('should set cookie with custom name', function () {
+            /*jshint camelcase: false */
+            resultObj.message = {
+              qewd_send_jwt_as_cookie: {
+                name: 'QUUX'
+              },
+              token: 'foo.bar.baz',
+              restMessage: {}
+            };
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.set).toHaveBeenCalledWith('Set-Cookie', 'QUUX=foo.bar.baz; path=/');
+            expect(res.locals.message.qewd_send_jwt_as_cookie).toBeUndefined();
+            expect(res.locals.message.token).toBeUndefined();
+            /*jshint camelcase: true */
+          });
+
+          it('should set cookie with custom directives', function () {
+            /*jshint camelcase: false */
+            resultObj.message = {
+              qewd_send_jwt_as_cookie: {
+                directives: [
+                 'path=/xxx',
+                 'HttpOnly'
+                ]
+              },
+              token: 'foo.bar.baz',
+              restMessage: {}
+            };
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.set).toHaveBeenCalledWith('Set-Cookie', 'JSESSIONID=foo.bar.baz; path=/xxx; HttpOnly');
+            expect(res.locals.message.qewd_send_jwt_as_cookie).toBeUndefined();
+            expect(res.locals.message.token).toBeUndefined();
+            /*jshint camelcase: true */
+          });
+        });
+      });
+
+      describe('restRequest', function () {
+        beforeEach(function () {
+          /*jshint camelcase: false */
+          resultObj.type = 'restRequest';
+          resultObj.ms_requestId = '1234';
+          /*jshint camelcase: true */
+        });
+
+        describe('qewd response headers', function () {
+          it('should ignore response headers (not an object)', function () {
+            /*jshint camelcase: false */
+            resultObj.message.qewd_response_headers = 'foo';
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.locals.message.qewd_response_headers).toBe('foo');
+            /*jshint camelcase: true */
+          });
+
+          it('should set response headers', function () {
+            /*jshint camelcase: false */
+            resultObj.message.qewd_response_headers = {
+              'x-foo': 'bar'
+            };
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.set).toHaveBeenCalledWith('x-foo', 'bar');
+            expect(res.locals.message.qewd_response_headers).toBeUndefined();
+            /*jshint camelcase: true */
+          });
+        });
+
+        describe('send jwt as cookie', function () {
+          it('should set cookie with default name', function () {
+            /*jshint camelcase: false */
+            resultObj.message = {
+              qewd_send_jwt_as_cookie: {},
+              token: 'foo.bar.baz'
+            };
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.set).toHaveBeenCalledWith('Set-Cookie', 'JSESSIONID=foo.bar.baz; path=/');
+            expect(res.locals.message.qewd_send_jwt_as_cookie).toBeUndefined();
+            expect(res.locals.message.token).toBeUndefined();
+            /*jshint camelcase: true */
+          });
+
+          it('should set cookie with custom name', function () {
+            /*jshint camelcase: false */
+            resultObj.message = {
+              qewd_send_jwt_as_cookie: {
+                name: 'QUUX'
+              },
+              token: 'foo.bar.baz'
+            };
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.set).toHaveBeenCalledWith('Set-Cookie', 'QUUX=foo.bar.baz; path=/');
+            expect(res.locals.message.qewd_send_jwt_as_cookie).toBeUndefined();
+            expect(res.locals.message.token).toBeUndefined();
+            /*jshint camelcase: true */
+          });
+
+          it('should set cookie with custom directives', function () {
+            /*jshint camelcase: false */
+            resultObj.message = {
+              qewd_send_jwt_as_cookie: {
+                directives: [
+                 'path=/xxx',
+                 'HttpOnly'
+                ]
+              },
+              token: 'foo.bar.baz'
+            };
+            /*jshint camelcase: true */
+
+            qx.handleMessage(req, res, next);
+            jasmine.clock().tick(timeout);
+
+            var handleResponse = q.handleMessage.calls.argsFor(0)[1];
+            handleResponse(resultObj);
+
+            /*jshint camelcase: false */
+            expect(res.set).toHaveBeenCalledWith('Set-Cookie', 'JSESSIONID=foo.bar.baz; path=/xxx; HttpOnly');
+            expect(res.locals.message.qewd_send_jwt_as_cookie).toBeUndefined();
+            expect(res.locals.message.token).toBeUndefined();
+            /*jshint camelcase: true */
+          });
+        });
       });
 
       describe('ewd_application', function () {


### PR DESCRIPTION
 - Fix unit test coverage (`qewd_response_headers` and `qewd_send_jwt_as_cookie` features)
 - Add integration tests (`qewd_response_headers` and `qewd_send_jwt_as_cookie` features)  for `restMessage` only
 - Bump deps